### PR TITLE
fix non canonical names in zoneparser

### DIFF
--- a/pdns/test-zoneparser_tng_cc.cc
+++ b/pdns/test-zoneparser_tng_cc.cc
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE(test_tng_record_types) {
     std::getline(ifs, type, ' ');
     std::getline(ifs, data, '\n');
     // see if these agree
-    BOOST_CHECK_EQUAL(rr.qname, host);
+    BOOST_CHECK_EQUAL(rr.qname.toString(), host);
     BOOST_CHECK_EQUAL(rr.ttl, ttl);
     BOOST_CHECK_EQUAL(rr.qtype.getName(), type);
     if (*(rr.content.rbegin()) != '.' && *(data.rbegin()) == '.') 

--- a/pdns/zoneparser-tng.cc
+++ b/pdns/zoneparser-tng.cc
@@ -298,17 +298,18 @@ bool ZoneParserTNG::get(DNSResourceRecord& rr, std::string* comment)
     goto retry;
   }
 
-  if(isspace(d_line[0])) 
+  string qname = makeString(d_line, parts[0]); // Don't use DNSName here!
+  if(isspace(d_line[0]))
     rr.qname=d_prevqname;
   else {
-    rr.qname=makeString(d_line, parts[0]); 
+    rr.qname=qname;
     parts.pop_front();
     if(!rr.qname.countLabels() || rr.qname.toString()[0]==';')
       goto retry;
   }
-  if(rr.qname=="@")
+  if(qname=="@")
     rr.qname=d_zonename;
-  else
+  else if(!isCanonical(qname))
     rr.qname += d_zonename;
   d_prevqname=rr.qname;
 


### PR DESCRIPTION
```
./testrunner --run_test=test_zoneparser_tng_cc
Running 1 test case...

*** No errors detected
```